### PR TITLE
Stack projects when screen width gets below 800px.

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -137,6 +137,23 @@ export default {
   justify-content: space-between;
 }
 
+@media only screen and (max-width: 800px) {
+  .projects {
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  .projects img {
+    width: 100%;
+    margin: 10px;
+  }
+
+  .projects p {
+    /* TODO: Fix this so that when the projects stack the text gets larger  */
+  }
+}
+
 .projects div {
   text-align: center;
   align-items: center;


### PR DESCRIPTION
Adds enhancement to stack projects when screen width gets below 800px. When this happens the text should actually do the opposite. It should grow into the new space and spread as wide as the Projects bar. There is some difficulty determining how to override this columnizing effect which is what's forcing the text to squeeze. Might need to move each `p` into it's own block?

This is an OK width (still not preferable).
![Screen Shot 2023-04-02 at 11 23 50 PM](https://user-images.githubusercontent.com/58452495/229427884-8629d742-9a8b-4a40-9bd4-8bb4726f0244.png)

This is not OK, and is how it is viewed on mobile.
![Screen Shot 2023-04-02 at 11 28 57 PM](https://user-images.githubusercontent.com/58452495/229428687-f55760be-eb58-4e77-82fb-25aff64b3b80.png)